### PR TITLE
Fix melonjs readme links.

### DIFF
--- a/breakouts/melonjs/README.md
+++ b/breakouts/melonjs/README.md
@@ -9,10 +9,12 @@ to focus on the game features.
 melonJS is an open-source HTML5 game engine, released under the 
 MIT license, and built in the spirit of a community based project.
 
-Web: www.melonjs.org
-Documentation : www.melonjs.org/docs/index.html
-Tutorial: www.melonjs.org/tutorial/index.html
-Source : https://github.com/obiot/melonJS
+Useful links:
+
+- Official Website: www.melonjs.org
+- Documentation : www.melonjs.org/docs/index.html
+- Tutorial: www.melonjs.org/tutorial/index.html
+- Source : https://github.com/melonjs/melonjs
 
 ##Breakout Status
 first version with all features implemented (including power-up/power-down)


### PR DESCRIPTION
This is a simple PR just to fix the official github repo on melonjs and organize the links into a list.
